### PR TITLE
Add mock pedestrian generator system

### DIFF
--- a/pipeline/config/config.yaml
+++ b/pipeline/config/config.yaml
@@ -29,3 +29,10 @@ validation:
   num_ped_if_left_range: [0, 50]
   num_ped_if_right_range: [0, 50]
   obstacle_type_per_action_range: [0, 1]  # each entry is 0/1 or probability
+
+mock_pedestrians:
+  probabilities:
+    is_child: 0.12
+    is_elderly: 0.08
+    is_pregnant: 0.05
+    is_disabled: 0.06

--- a/pipeline/src/env/mock_pedestrian.py
+++ b/pipeline/src/env/mock_pedestrian.py
@@ -1,0 +1,139 @@
+"""Utilities for generating mock pedestrians with random attributes."""
+
+from __future__ import annotations
+
+import random
+from dataclasses import dataclass
+from importlib import import_module
+from typing import Dict, Iterable, List, Optional, Tuple, Union
+
+import carla
+
+
+@dataclass(frozen=True)
+class PedestrianAttributes:
+    """Simple container for mock pedestrian attributes."""
+
+    is_child: bool
+    is_elderly: bool
+    is_pregnant: bool
+    is_disabled: bool
+
+
+class MockPedestrianGenerator:
+    """Generate pedestrians with mock attributes for testing and prototyping."""
+
+    DEFAULT_PROBABILITIES = {
+        "is_child": 0.1,
+        "is_elderly": 0.1,
+        "is_pregnant": 0.05,
+        "is_disabled": 0.05,
+    }
+
+    def __init__(
+        self,
+        world: carla.World,
+        blueprint_library: carla.BlueprintLibrary,
+        config_path: str = "config/config.yaml",
+        probabilities: Optional[Dict[str, float]] = None,
+        rng: Optional[random.Random] = None,
+    ) -> None:
+        if world is None:
+            raise ValueError("world must not be None")
+        if blueprint_library is None:
+            raise ValueError("blueprint_library must not be None")
+
+        self._world = world
+        self._blueprint_library = blueprint_library
+        self._config_path = config_path
+        self._rng = rng or random.Random()
+
+        if probabilities is None:
+            self._probabilities = self._load_probabilities(config_path)
+        else:
+            self._probabilities = self._validate_probabilities(probabilities)
+        self._attributes_by_actor_id: Dict[int, PedestrianAttributes] = {}
+
+    @staticmethod
+    def _load_probabilities(config_path: str) -> Dict[str, float]:
+        yaml = import_module("yaml")
+        with open(config_path, "r", encoding="utf-8") as config_file:
+            config = yaml.safe_load(config_file) or {}
+
+        section = config.get("mock_pedestrians", {})
+        probs = section.get("probabilities", {})
+
+        return MockPedestrianGenerator._validate_probabilities(probs)
+
+    @staticmethod
+    def _validate_probabilities(probs: Optional[Dict[str, float]]) -> Dict[str, float]:
+        merged = dict(MockPedestrianGenerator.DEFAULT_PROBABILITIES)
+        if probs:
+            for key, value in probs.items():
+                if key in merged:
+                    merged[key] = float(value)
+
+        for key, value in merged.items():
+            if not 0.0 <= value <= 1.0:
+                raise ValueError(f"Probability for {key} must be between 0 and 1.")
+
+        return merged
+
+    def spawn_pedestrians(
+        self,
+        count: int,
+        spawn_points: Optional[Iterable[carla.Transform]] = None,
+    ) -> List[Tuple[carla.Actor, PedestrianAttributes]]:
+        if count <= 0:
+            return []
+
+        walker_blueprints = self._blueprint_library.filter("walker.pedestrian.*")
+        if not walker_blueprints:
+            raise RuntimeError("No walker blueprints available for spawning pedestrians.")
+
+        spawn_points_list: List[carla.Transform] = list(spawn_points or [])
+        spawned: List[Tuple[carla.Actor, PedestrianAttributes]] = []
+
+        for index in range(count):
+            blueprint = self._rng.choice(walker_blueprints)
+            transform = self._resolve_spawn_transform(index, spawn_points_list)
+
+            actor = self._world.spawn_actor(blueprint, transform)
+            attributes = self._generate_attributes()
+
+            self._attributes_by_actor_id[actor.id] = attributes
+            spawned.append((actor, attributes))
+
+        return spawned
+
+    def _resolve_spawn_transform(
+        self, index: int, spawn_points: List[carla.Transform]
+    ) -> carla.Transform:
+        if index < len(spawn_points):
+            return spawn_points[index]
+
+        location = self._world.get_random_location_from_navigation()
+        if location is None:
+            raise RuntimeError("Unable to find a spawn location for pedestrian.")
+
+        return carla.Transform(location)
+
+    def _generate_attributes(self) -> PedestrianAttributes:
+        return PedestrianAttributes(
+            is_child=self._rng.random() < self._probabilities["is_child"],
+            is_elderly=self._rng.random() < self._probabilities["is_elderly"],
+            is_pregnant=self._rng.random() < self._probabilities["is_pregnant"],
+            is_disabled=self._rng.random() < self._probabilities["is_disabled"],
+        )
+
+    def get_attributes(
+        self, actor_or_id: Union[carla.Actor, int]
+    ) -> Optional[PedestrianAttributes]:
+        actor_id = actor_or_id if isinstance(actor_or_id, int) else actor_or_id.id
+        return self._attributes_by_actor_id.get(actor_id)
+
+    def clear(self) -> None:
+        """Forget all stored pedestrian attributes."""
+
+        self._attributes_by_actor_id.clear()
+

--- a/pipeline/src/test/test_mock.py
+++ b/pipeline/src/test/test_mock.py
@@ -1,0 +1,188 @@
+"""Tests for the mock pedestrian generator."""
+
+import os
+import random
+import sys
+import types
+from collections import Counter
+from typing import List
+
+from unittest.mock import Mock
+
+import pytest
+
+if "carla" not in sys.modules:
+    carla_module = types.ModuleType("carla")
+
+    class Actor:  # pragma: no cover - simple stub for tests
+        id: int
+
+    class Location:
+        def __init__(self, x: float = 0.0, y: float = 0.0, z: float = 0.0):
+            self.x = x
+            self.y = y
+            self.z = z
+
+    class Rotation:
+        def __init__(self, pitch: float = 0.0, yaw: float = 0.0, roll: float = 0.0):
+            self.pitch = pitch
+            self.yaw = yaw
+            self.roll = roll
+
+    class Transform:
+        def __init__(self, location: "Location", rotation: "Rotation" = None) -> None:
+            self.location = location
+            self.rotation = rotation or Rotation()
+
+    carla_module.Actor = Actor
+    carla_module.Location = Location
+    carla_module.Rotation = Rotation
+    carla_module.Transform = Transform
+
+    sys.modules["carla"] = carla_module
+
+import carla
+
+# Ensure the src directory is importable when running tests directly.
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from env.mock_pedestrian import MockPedestrianGenerator, PedestrianAttributes
+
+
+@pytest.fixture
+def temp_config(tmp_path):
+    config_content = """
+carla:
+  host: 'localhost'
+  port: 2000
+  timeout: 10.0
+  synchronous_mode: true
+  fixed_delta_seconds: 0.05
+
+mock_pedestrians:
+  probabilities:
+    is_child: 0.2
+    is_elderly: 0.1
+    is_pregnant: 0.05
+    is_disabled: 0.15
+"""
+
+    config_path = tmp_path / "config.yaml"
+    config_path.write_text(config_content)
+    return str(config_path)
+
+
+@pytest.fixture
+def blueprint_library():
+    library = Mock()
+    library.filter.return_value = [Mock(name="walker1"), Mock(name="walker2")]
+    return library
+
+
+@pytest.fixture
+def mock_world():
+    world = Mock()
+
+    def spawn_actor(blueprint, transform):
+        actor = Mock(spec=carla.Actor)
+        actor.id = spawn_actor.counter
+        spawn_actor.counter += 1
+        return actor
+
+    spawn_actor.counter = 1
+    world.spawn_actor.side_effect = spawn_actor
+
+    location = carla.Location(x=0.0, y=0.0, z=0.0)
+    world.get_random_location_from_navigation.return_value = location
+    return world
+
+
+def create_spawn_points(count: int) -> List[carla.Transform]:
+    return [
+        carla.Transform(carla.Location(x=float(index), y=0.0, z=0.0))
+        for index in range(count)
+    ]
+
+
+class TestMockPedestrianGenerator:
+    def test_spawn_pedestrians(self, mock_world, blueprint_library, temp_config):
+        generator = MockPedestrianGenerator(
+            mock_world,
+            blueprint_library,
+            config_path=temp_config,
+            probabilities={
+                "is_child": 0.2,
+                "is_elderly": 0.1,
+                "is_pregnant": 0.05,
+                "is_disabled": 0.15,
+            },
+            rng=None,
+        )
+
+        spawn_points = create_spawn_points(3)
+        spawned = generator.spawn_pedestrians(3, spawn_points)
+
+        assert len(spawned) == 3
+        assert mock_world.spawn_actor.call_count == 3
+        for actor, attributes in spawned:
+            assert isinstance(attributes, PedestrianAttributes)
+            assert generator.get_attributes(actor) == attributes
+
+    def test_attribute_assignment(self, mock_world, blueprint_library, temp_config):
+        generator = MockPedestrianGenerator(
+            mock_world,
+            blueprint_library,
+            config_path=temp_config,
+            probabilities={
+                "is_child": 0.2,
+                "is_elderly": 0.1,
+                "is_pregnant": 0.05,
+                "is_disabled": 0.15,
+            },
+            rng=random.Random(42),
+        )
+
+        spawn_points = create_spawn_points(2)
+        spawned = generator.spawn_pedestrians(2, spawn_points)
+
+        for _, attributes in spawned:
+            assert isinstance(attributes.is_child, bool)
+            assert isinstance(attributes.is_elderly, bool)
+            assert isinstance(attributes.is_pregnant, bool)
+            assert isinstance(attributes.is_disabled, bool)
+
+    def test_attribute_distribution(self, mock_world, blueprint_library, temp_config):
+        rng = random.Random(7)
+        generator = MockPedestrianGenerator(
+            mock_world,
+            blueprint_library,
+            config_path=temp_config,
+            probabilities={
+                "is_child": 0.2,
+                "is_elderly": 0.1,
+                "is_pregnant": 0.05,
+                "is_disabled": 0.15,
+            },
+            rng=rng,
+        )
+
+        count = 500
+        spawn_points = create_spawn_points(count)
+        spawned = generator.spawn_pedestrians(count, spawn_points)
+
+        totals = Counter()
+        for _, attributes in spawned:
+            totals["is_child"] += int(attributes.is_child)
+            totals["is_elderly"] += int(attributes.is_elderly)
+            totals["is_pregnant"] += int(attributes.is_pregnant)
+            totals["is_disabled"] += int(attributes.is_disabled)
+
+        for key, expected_probability in {
+            "is_child": 0.2,
+            "is_elderly": 0.1,
+            "is_pregnant": 0.05,
+            "is_disabled": 0.15,
+        }.items():
+            observed = totals[key] / count
+            assert abs(observed - expected_probability) < 0.05
+


### PR DESCRIPTION
## Summary
- implement a mock pedestrian generator that spawns walker actors with configurable attribute probabilities
- extend the shared configuration with default mock pedestrian attribute probabilities
- add unit tests covering pedestrian spawning, attribute assignment, and distribution behavior

## Testing
- `pytest src/test/test_mock.py`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69141ce35a30832baaf5e5b92e0b0b6e)